### PR TITLE
Update PHP version requirements in composer.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of global `array_*` functions appending to the native PHP set.
 
 ## Requirements
 
-- **php**: >=5.3.0
+- **php**: >=7.2.0
 
 ## Installing
 

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
 		}
 	],
 	"require": {
-		"php" : ">=5.3.0"
+		"php" : ">=7.2.0"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.8|~9|~11"
+		"phpunit/phpunit": "~8|~9|~11"
 	},
 	"autoload"   : {
 		"files": ["src/array.php"]


### PR DESCRIPTION
Raises the floor to PHP 7.2 as it is the earliest supported by a working version of PHPUnit.